### PR TITLE
Enhance the main example by removing the useMaterial3 flag, which is …

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -28,9 +28,7 @@ class MyApp extends StatelessWidget {
       title: 'Flutter Gemini',
       themeMode: ThemeMode.dark,
       debugShowCheckedModeBanner: false,
-      darkTheme: ThemeData.dark(
-        useMaterial3: true,
-      ).copyWith(
+      darkTheme: ThemeData.dark().copyWith(
           colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
           cardTheme: CardTheme(color: Colors.blue.shade900)),
       home: const MyHomePage(),


### PR DESCRIPTION
### Problem
Fix [Example contains the default useMaterial3 = true](https://github.com/babakcode/flutter_gemini/issues/21) #21 

### Reason
As of version `v3.16`, [ThemeData.useMaterial3](https://api.flutter.dev/flutter/material/ThemeData/useMaterial3.html) is set `true` by [default](https://docs.flutter.dev/release/breaking-changes/material-3-default#:~:text=Flutter's%20Material%20widgets%20now%20fully,textTheme%20.).


### Changed file
- `example/lib/main.dart`


<details open><summary>Code sample</summary>

``` dart
class MyApp extends StatelessWidget {
  const MyApp({super.key});

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      title: 'Flutter Gemini',
      themeMode: ThemeMode.dark,
      debugShowCheckedModeBanner: false,
      darkTheme: ThemeData.dark(
        useMaterial3: true, /// TODO: We can remove it
      ).copyWith(
          colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
          cardTheme: CardTheme(color: Colors.blue.shade900)),
      home: const MyHomePage(),
    );
  }
}
```